### PR TITLE
Added the posibility of running selenium tests using a selenium stand…

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you want to execute all the integration tests in the library, please take a l
 
 #### Testing with alternative SDK
 
-If you want to test your changes in a different sdk, you can use the official docker images of maven in the followinf way:
+If you want to test your changes in a different sdk, you can use the official docker images of maven in the following way:
 
 First, create a docker volume where all dependencies will be stored (to avoid downloading all dependencies on every run)
 
@@ -90,6 +90,12 @@ _**print log at DEBUG level when running a test**_
 _**-DSELENIUM_GRID and -DFORCE_BROWSER for Selenium features**_
 
 ` mvn verify -Dit.test=com.privalia.myproject.mypackage.CucumberSeleniumIT -DSELENIUM_GRID=127.0.0.1:4444`
+
+_**-DSELENIUM_NODE and -DSELENIUM_NODE_TYPE for Selenium features**_
+
+Instead of using a selenium grid, you can directly conect to a standalone node by specifiying its address and the type of browser it supports
+
+` mvn verify -Dit.test=com.privalia.myproject.mypackage.CucumberSeleniumIT -DSELENIUM_NODE=127.0.0.1:4444 -DSELENIUM_NODE_TYPE=chrome`
 
 _**-Dmaven.failsafe.debug to debug with maven and IDE.**_
 

--- a/src/main/java/com/privalia/qa/data/BrowsersDataProvider.java
+++ b/src/main/java/com/privalia/qa/data/BrowsersDataProvider.java
@@ -66,7 +66,7 @@ public final class BrowsersDataProvider {
     /**
      * Get unique browsers available in a selenium grid.
      *
-     * @param context context
+     * @param context         context
      * @param testConstructor testConstructor
      * @return an iterator
      * @throws Exception exception
@@ -89,10 +89,10 @@ public final class BrowsersDataProvider {
     /**
      * Get the browsers available with "iOS" as platformName in a selenium grid.
      *
-     * @param context           context
-     * @param testConstructor   testConstructor
-     * @return                  an iterator
-     * @throws Exception        Exception
+     * @param context         context
+     * @param testConstructor testConstructor
+     * @return an iterator
+     * @throws Exception Exception
      */
     @DataProvider(parallel = true)
     public static Object[] availableIOSBrowsers(ITestContext context, Constructor<?> testConstructor)
@@ -189,7 +189,43 @@ public final class BrowsersDataProvider {
                 }
             }
         } else {
-            LOGGER.warn("No Selenium Grid address specified!. Please use -DSELENIUM_GRID to supply a valid address");
+
+            String node = System.getProperty("SELENIUM_NODE");
+
+            if (node == null) {
+                LOGGER.warn("No Selenium Grid or Node address specified!. Searching for node in localhost:4444....");
+                node = "localhost:4444";
+            }
+
+            Document doc;
+            try {
+                doc = Jsoup.connect("http://" + node + "/wd/hub/static/resource/hub.html").timeout(DEFAULT_TIMEOUT).get();
+            } catch (IOException e) {
+                LOGGER.debug("Exception on connecting to Selenium node: {}", e.getMessage());
+                return response;
+            }
+
+            /**
+             * the process for connecting to a standalone node is the same as with the selenium grid, so SELENIUM_GRID is
+             * set to the value of the address of the node (the SELENIUM_GRID variable is later used in HoolGSpec class to
+             * create the connection)
+             */
+            System.setProperty("SELENIUM_GRID", node);
+
+
+            /**
+             * Is necessary to set the browser type the node supports, since this informacion is later used in the
+             * HoolGSpec class to create the correct capabilities object
+             */
+            String nodeType = System.getProperty("SELENIUM_NODE_TYPE");
+
+            if (nodeType == null) {
+                LOGGER.warn("No Selenium Node browser type specified!. Using 'chrome' as default....");
+                response.add("chrome_1.0");
+            } else {
+                response.add(nodeType + "_1.0");
+            }
+
         }
         // Sort response
         Collections.sort(response);


### PR DESCRIPTION
Added the possibility of running selenium tests using a selenium standalone node

The address of the node can be specified using -DSELENIUM_NODE
The node type can be specified using -DSELENIUM_NODE_TYPE

if no information is supplied when running the test, the library will default to use SELENIUM_NODE=localhost:4444 and SELENIUM_NODE_TYPE=chrome