### PR TITLE
Release/2.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ jobs:
       name: $project_version
       overwrite: true
 
+  - stage: deploy
     name: "Deploy the generated artifact to maven central"
     if: branch =~ ^release\/.*$
     deploy:
@@ -76,6 +77,7 @@ jobs:
         all_branches: true
         condition: ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} =~ ^release\/.*$
 
+  - stage: deploy
     name: "Publish the resulting javadoc to github pages"
     if: branch =~ ^release\/.*$
     deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
 before_deploy:
     - mvn help:evaluate -N -Dexpression=project.version|grep -v '\['
     - export project_version=$(mvn help:evaluate -N -Dexpression=project.version|grep -v '\[')
+    - mvn clean install -Dmaven.test.skip=true
 
 jobs:
   include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.3
+
+* GivenGSpec, WhenGSpec, ThenGSpec classes were removed and steps definitions were organized in a more logical way (This change may have some breaking changes to clients that still rely on the aforementioned classes)
+
+* Step definition location is now hidden by default when running tests. The variable -DSHOW_STACK_INFO can be used to reveal it, together with information about the value of each parameter passed to the underlying test definition function
+
 ## 2.0.2
 
 * Updated jackson-databind dependency to resolve security warning in github

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.privaliatech</groupId>
     <artifactId>gingerspec</artifactId>
-    <version>2.0.3-SNAPSHOT</version>
+    <version>2.0.3</version>
 
     <name>Privalia GingerSpec framework</name>
     <description>Acceptance Test library. Testing runtime to rule over Privalia's acceptance tests.</description>


### PR DESCRIPTION
## 2.0.3

* GivenGSpec, WhenGSpec, ThenGSpec classes were removed and steps definitions were organized in a more logical way (This change may have some breaking changes to clients that still rely on the aforementioned classes)

* Step definition location is now hidden by default when running tests. The variable -DSHOW_STACK_INFO can be used to reveal it, together with information about the value of each parameter passed to the underlying test definition function
