### PR TITLE
Local browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Instead of using a selenium grid, you can directly conect to a standalone node b
 
 ` mvn verify -Dit.test=com.privalia.myproject.mypackage.CucumberSeleniumIT -DSELENIUM_NODE=127.0.0.1:4444 -DSELENIUM_NODE_TYPE=chrome`
 
+_**Run Selenium features using local browser**_
+
+If neither selenium grid nor a standalone selenium node server is specified, gingerspec will automatically download the correct driver to run the test
+
+` mvn verify -Dit.test=com.privalia.myproject.mypackage.CucumberSeleniumIT` (you can use -Dbrowser=<browser> to specify the browser type. Currently supports chrome/firefox )
+
 _**-Dmaven.failsafe.debug to debug with maven and IDE.**_
 
 ` mvn verify -DSECS=AGENT_LIST=1,2 -Dit.test=com.privalia.qa.ATests.LoopTagAspectIT -Dmaven.failsafe.debug`

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <org.jacoco.core.version>0.7.5.201505241946</org.jacoco.core.version>
         <aspectjweaver.version>1.8.8</aspectjweaver.version>
         <cassandra-driver-core.version>3.2.0</cassandra-driver-core.version>
-        <guava.version>21.0</guava.version>
+        <guava.version>23.0</guava.version>
         <lz4.version>1.2.0</lz4.version>
         <httpclient.version>4.5.1</httpclient.version>
         <mongo-java-driver.version>2.12.3</mongo-java-driver.version>
@@ -618,6 +618,11 @@
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
             <version>1.9.16</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>3.6.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/privalia/qa/specs/CommonG.java
+++ b/src/main/java/com/privalia/qa/specs/CommonG.java
@@ -67,7 +67,7 @@ public class CommonG {
 
     private final Logger logger = LoggerFactory.getLogger(ThreadProperty.get("class"));
 
-    private RemoteWebDriver driver = null;
+    private WebDriver driver = null;
 
     private String browserName = null;
 
@@ -490,7 +490,7 @@ public class CommonG {
      *
      * @return RemoteWebDriver
      */
-    public RemoteWebDriver getDriver() {
+    public WebDriver getDriver() {
         return driver;
     }
 
@@ -499,7 +499,7 @@ public class CommonG {
      *
      * @param driver driver to be used for testing
      */
-    public void setDriver(RemoteWebDriver driver) {
+    public void setDriver(WebDriver driver) {
         this.driver = driver;
     }
 

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -58,6 +58,8 @@
         <logger name="com.ning.http.client.AsyncHttpClientAsyncHttpClient" level="ERROR"/>
         <logger name="io.confluent.kafka" level="WARN"/>
         <logger name="kafka.utils" level="WARN"/>
+        <logger name="org.apache.http" level="WARN" />
+        <logger name="io.github.bonigarcia" level="ERROR" />
 
         <!--To make the output of SoapService logs less verbose when using debug option-->
         <logger name="com.predic8" level="WARN"/>


### PR DESCRIPTION
Added support for using the local browser when running selenium tests

If neither SELENIUM_GRID nor SELENIUM_NODE variables are specified, gingerspec will try to download the appropriate driver for the current operating system so the test can be run using the local browser

Check https://github.com/bonigarcia/webdrivermanager for more information

