### PR TITLE
Release/2.1.0 rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.1.0-RC3
+
+*  Fixed bug that was causing that during assertion errors, no screen capture was taken when driver was instance of mobiledriver (appium)
+
+* Added a more descriptive error message to evaluateJSONElementOperation method
+
 ## 2.1.0-RC2
 
 * Changed the hasAtLeast method from assertGreaterThan to assertGreaterThanOrEqual. Under certain conditions, no screen capture was taken when an exception occurred 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.privaliatech</groupId>
     <artifactId>gingerspec</artifactId>
-    <version>2.1.0-RC2</version>
+    <version>2.1.0-RC3</version>
 
     <name>Privalia GingerSpec framework</name>
     <description>Acceptance Test library. Testing runtime to rule over Privalia's acceptance tests.</description>

--- a/src/main/java/com/privalia/qa/aspects/SeleniumAspect.java
+++ b/src/main/java/com/privalia/qa/aspects/SeleniumAspect.java
@@ -21,6 +21,7 @@ import com.privalia.qa.specs.BaseGSpec;
 import com.privalia.qa.specs.CommonG;
 import com.privalia.qa.specs.SeleniumGSpec;
 import com.privalia.qa.utils.PreviousWebElements;
+import io.appium.java_client.MobileDriver;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -129,9 +130,15 @@ public class SeleniumAspect extends BaseGSpec {
                     common.setDriver((RemoteWebDriver) driver);
                     suffix = "exception";
                 }
-                common.captureEvidence(driver, "framehtmlSource", suffix);
-                common.captureEvidence(driver, "htmlSource", suffix);
-                common.captureEvidence(driver, "screenCapture", suffix);
+
+                if (driver instanceof MobileDriver) {
+                    common.captureEvidence(driver, "mobileScreenCapture", suffix);
+                    common.captureEvidence(driver, "mobilePageSource", suffix);
+                } else {
+                    common.captureEvidence(driver, "framehtmlSource", suffix);
+                    common.captureEvidence(driver, "htmlSource", suffix);
+                    common.captureEvidence(driver, "screenCapture", suffix);
+                }
                 logger.info("Screenshots are available at target/executions");
             } else {
                 logger.info("Got no Selenium driver to capture a screen");

--- a/src/main/java/com/privalia/qa/specs/CommonG.java
+++ b/src/main/java/com/privalia/qa/specs/CommonG.java
@@ -836,6 +836,44 @@ public class CommonG {
             } catch (IOException e) {
                 logger.error("Exception on copying browser screen capture", e);
             }
+
+        } else if ("mobileScreenCapture".equals(type)) {
+
+            outputFile = dir + clazz + "/"
+                    + ThreadProperty.get("feature") + "." + ThreadProperty.get("scenario") + "/"  +
+                    currentData + ts.toString() + suffix;
+
+            outputFile = outputFile.replaceAll(" ", "_") + ".png";
+
+            try {
+                File file = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
+                FileUtils.copyFile(file, new File(outputFile));
+            } catch (Exception e) {
+                logger.error("Exception when taking screenshot", e);
+            }
+
+        } else if ("mobilePageSource".equals(type)) {
+
+            outputFile = dir + clazz + "/"
+                    + ThreadProperty.get("feature") + "." + ThreadProperty.get("scenario") + "/"  +
+                    currentData + ts.toString() + suffix;
+
+            outputFile = outputFile.replaceAll(" ", "_") + ".xml";
+
+            String source = driver.getPageSource();
+
+            File fout = new File(outputFile);
+            boolean dirs = fout.getParentFile().mkdirs();
+
+            try (FileOutputStream fos = new FileOutputStream(fout, true)) {
+                Writer out = new OutputStreamWriter(fos, "UTF8");
+                PrintWriter writer = new PrintWriter(out, false);
+                writer.append(source);
+                writer.close();
+                out.close();
+            } catch (IOException e) {
+                logger.error("Exception on evidence capture", e);
+            }
         }
 
         return outputFile;

--- a/src/main/java/com/privalia/qa/specs/CommonG.java
+++ b/src/main/java/com/privalia/qa/specs/CommonG.java
@@ -2053,7 +2053,7 @@ public class CommonG {
                     }
                     break;
                 default:
-                    Assertions.fail("Not implemented condition");
+                    Assertions.fail("Not valid operation '" + condition + "'. Valid operations: 'equal', 'not equal', 'contains', 'does not contain', 'length', 'exists', 'does not exists' and 'size'");
                     break;
             }
         } else if (o instanceof List) {

--- a/src/main/java/com/privalia/qa/specs/SeleniumGSpec.java
+++ b/src/main/java/com/privalia/qa/specs/SeleniumGSpec.java
@@ -279,8 +279,8 @@ public class SeleniumGSpec extends BaseGSpec {
 
         if (atLeast != null) {
             wel = commonspec.locateElement(method, element, -1);
-            assertThat(this.commonspec, wel).as("Element count doesnt match").hasAtLeast(expectedCount);
-
+            PreviousWebElements pwel = new PreviousWebElements(wel);
+            assertThat(this.commonspec, pwel).as("Element count doesnt match").hasAtLeast(expectedCount);
         } else {
             wel = commonspec.locateElement(method, element, expectedCount);
         }


### PR DESCRIPTION
*  Fixed bug that was causing that during assertion errors, no screen capture was taken when driver was instance of mobiledriver (appium)

* Added a more descriptive error message to evaluateJSONElementOperation method