### PR TITLE
Feature/selenium local

### DIFF
--- a/src/main/java/com/privalia/qa/aspects/ReplacementAspect.java
+++ b/src/main/java/com/privalia/qa/aspects/ReplacementAspect.java
@@ -53,9 +53,9 @@ import java.util.List;
  * @author Jose Fernandez
  */
 @Aspect
-public class ReplacementAspect {
+public final class ReplacementAspect {
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass().getCanonicalName());
+    private static Logger logger = LoggerFactory.getLogger(ReplacementAspect.class.getCanonicalName());
 
     private StepDefinitionMatch lastEchoedStep;
 
@@ -217,7 +217,7 @@ public class ReplacementAspect {
     }
 
 
-    protected String replacedElement(String el, JoinPoint jp) throws NonReplaceableException, ConfigurationException, URISyntaxException, FileNotFoundException {
+    public static String replacedElement(String el, JoinPoint jp) throws NonReplaceableException, ConfigurationException, URISyntaxException, FileNotFoundException {
         if (el.contains("${")) {
             el = replaceEnvironmentPlaceholders(el, jp);
         }
@@ -233,9 +233,9 @@ public class ReplacementAspect {
         return el;
     }
 
-    private File getfile(String environment) throws URISyntaxException, FileNotFoundException {
+    private static File getfile(String environment) throws URISyntaxException, FileNotFoundException {
 
-        URL url = getClass().getClassLoader().getResource("configuration/" + environment + ".properties");
+        URL url = ReplacementAspect.class.getClassLoader().getResource("configuration/" + environment + ".properties");
 
         if (url != null) {
             return new File(url.toURI());
@@ -269,7 +269,7 @@ public class ReplacementAspect {
      * @throws NonReplaceableException NonReplaceableException
      * @throws FileNotFoundException   FileNotFoundException
      */
-    protected String replacePropertyPlaceholders(String element, JoinPoint pjp) throws ConfigurationException, URISyntaxException, NonReplaceableException, FileNotFoundException {
+    protected static String replacePropertyPlaceholders(String element, JoinPoint pjp) throws ConfigurationException, URISyntaxException, NonReplaceableException, FileNotFoundException {
 
         String newVal = element;
         Parameters params = new Parameters();
@@ -279,14 +279,14 @@ public class ReplacementAspect {
         String environment = System.getProperty("env", null);
         if (environment != null) {
             FileBasedConfigurationBuilder<FileBasedConfiguration> config2 = new FileBasedConfigurationBuilder<FileBasedConfiguration>(
-                    PropertiesConfiguration.class).configure(params.properties().setFile(this.getfile(environment)));
+                    PropertiesConfiguration.class).configure(params.properties().setFile(getfile(environment)));
             config.addConfiguration(config2.getConfiguration());
         }
 
         /*Add the file common.properties as a source of properties*/
         FileBasedConfigurationBuilder<FileBasedConfiguration> config1 = new FileBasedConfigurationBuilder<FileBasedConfiguration>(
                 PropertiesConfiguration.class)
-                .configure(params.properties().setFile(this.getfile("common")));
+                .configure(params.properties().setFile(getfile("common")));
 
         config.addConfiguration(config1.getConfiguration());
 
@@ -328,7 +328,7 @@ public class ReplacementAspect {
      * @return String
      * @throws NonReplaceableException exception
      */
-    protected String replaceCodePlaceholders(String element, JoinPoint pjp) throws NonReplaceableException {
+    protected static String replaceCodePlaceholders(String element, JoinPoint pjp) throws NonReplaceableException {
         String newVal = element;
         while (newVal.contains("@{")) {
             String placeholder = newVal.substring(newVal.indexOf("@{"), newVal.indexOf("}", newVal.indexOf("@{")) + 1);
@@ -355,7 +355,7 @@ public class ReplacementAspect {
                         try {
                             ifs = NetworkInterface.getByName(subproperty).getInetAddresses();
                         } catch (SocketException e) {
-                            this.logger.error(e.getMessage());
+                            logger.error(e.getMessage());
                         }
                         while (ifs.hasMoreElements() && !found) {
                             InetAddress itf = ifs.nextElement();
@@ -392,7 +392,7 @@ public class ReplacementAspect {
      * @param pjp     JoinPoint
      * @return String string
      */
-    protected String replaceReflectionPlaceholders(String element, JoinPoint pjp) {
+    protected static String replaceReflectionPlaceholders(String element, JoinPoint pjp) {
         String newVal = element;
         while (newVal.contains("!{")) {
             String placeholder = newVal.substring(newVal.indexOf("!{"),
@@ -423,7 +423,7 @@ public class ReplacementAspect {
      * @return String
      * @throws NonReplaceableException exception
      */
-    protected String replaceEnvironmentPlaceholders(String element, JoinPoint jp) throws NonReplaceableException {
+    protected static String replaceEnvironmentPlaceholders(String element, JoinPoint jp) throws NonReplaceableException {
         String newVal = element;
         while (newVal.contains("${")) {
             String placeholder = newVal.substring(newVal.indexOf("${"),

--- a/src/main/java/com/privalia/qa/specs/CommonG.java
+++ b/src/main/java/com/privalia/qa/specs/CommonG.java
@@ -16,14 +16,13 @@ import com.ning.http.client.Response;
 import com.ning.http.client.cookie.Cookie;
 import com.privalia.qa.aspects.ReplacementAspect;
 import com.privalia.qa.conditions.Conditions;
-import com.privalia.qa.exceptions.NonReplaceableException;
 import com.privalia.qa.utils.*;
 import io.appium.java_client.MobileDriver;
 import io.cucumber.datatable.DataTable;
 import io.restassured.specification.RequestSpecification;
 import org.apache.commons.collections.IteratorUtils;
-import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
+import org.aspectj.lang.JoinPoint;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.hjson.JsonValue;
@@ -39,16 +38,12 @@ import org.openqa.selenium.support.ui.Wait;
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ru.yandex.qatools.ashot.AShot;
-import ru.yandex.qatools.ashot.Screenshot;
-import ru.yandex.qatools.ashot.shooting.ShootingStrategies;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.*;
@@ -2180,7 +2175,21 @@ public class CommonG {
         return cookiesAttributes;
     }
 
-
+    /**
+     * Returns the value of the given placeholder as used in the gherkin step
+     * <pre>
+     * Examples:
+     * {@code
+     *      getVariable("${variable}")      //returns the java property
+     *      getVariable("!{variable}")      //returns the thread property
+     *      getVariable("#{variable}")      //returns the corresponding value from the properties file.
+     *      getVariable("@{variable}")      //returns attribute value
+     * }
+     * </pre>
+     * @see ReplacementAspect#replacedElement(String, JoinPoint) 
+     * @param variable      Variable placeholder as used in the gherkin file
+     * @return              Value assign to that variable
+     */
     public String getVariable(String variable) {
         try {
             return ReplacementAspect.replacedElement(variable, null);

--- a/src/main/java/com/privalia/qa/specs/CommonG.java
+++ b/src/main/java/com/privalia/qa/specs/CommonG.java
@@ -14,12 +14,15 @@ import com.ning.http.client.AsyncHttpClient;
 import com.ning.http.client.Realm;
 import com.ning.http.client.Response;
 import com.ning.http.client.cookie.Cookie;
+import com.privalia.qa.aspects.ReplacementAspect;
 import com.privalia.qa.conditions.Conditions;
+import com.privalia.qa.exceptions.NonReplaceableException;
 import com.privalia.qa.utils.*;
 import io.appium.java_client.MobileDriver;
 import io.cucumber.datatable.DataTable;
 import io.restassured.specification.RequestSpecification;
 import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
@@ -45,6 +48,7 @@ import java.awt.image.BufferedImage;
 import java.io.*;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.*;
@@ -2174,6 +2178,15 @@ public class CommonG {
                     null, 999999, false, false));
         }
         return cookiesAttributes;
+    }
+
+
+    public String getVariable(String variable) {
+        try {
+            return ReplacementAspect.replacedElement(variable, null);
+        } catch (Exception e) {
+            return null;
+        }
     }
 
 }

--- a/src/main/java/com/privalia/qa/specs/CommonG.java
+++ b/src/main/java/com/privalia/qa/specs/CommonG.java
@@ -65,7 +65,7 @@ public class CommonG {
 
     private static final int DEFAULT_SLEEP_TIME = 1500;
 
-    private final Logger logger = LoggerFactory.getLogger(ThreadProperty.get("class"));
+    private final Logger logger = LoggerFactory.getLogger((ThreadProperty.get("class") != null ? ThreadProperty.get("class") : this.getClass().getName()));
 
     private WebDriver driver = null;
 

--- a/src/main/java/com/privalia/qa/specs/CommonG.java
+++ b/src/main/java/com/privalia/qa/specs/CommonG.java
@@ -2186,7 +2186,7 @@ public class CommonG {
      *      getVariable("@{variable}")      //returns attribute value
      * }
      * </pre>
-     * @see ReplacementAspect#replacedElement(String, JoinPoint) 
+     * @see ReplacementAspect#replacedElement(String, JoinPoint)
      * @param variable      Variable placeholder as used in the gherkin file
      * @return              Value assign to that variable
      */

--- a/src/main/java/com/privalia/qa/specs/RestSpec.java
+++ b/src/main/java/com/privalia/qa/specs/RestSpec.java
@@ -78,7 +78,7 @@ public class RestSpec extends BaseGSpec {
      * @param isSecured     Indicates if https:// should be used (if false, defaults to http://)
      * @param restHost      Port where the API is running. Defaults to 80 if null
      */
-    @Given("^I( securely)? send requests to '(.+?)'$")
+    @Given("^I( securely)? send requests to '(.*)'$")
     public void setupApp(String isSecured, String restHost) {
         String restProtocol = "http://";
         String restPort = null;
@@ -142,7 +142,7 @@ public class RestSpec extends BaseGSpec {
      * @param envVar        Environment variable where JSON is stored
      * @param table         Data table in which each row stores one expression
      */
-    @Then("^'(.+?)' matches the following cases:$")
+    @Then("^'(.*)' matches the following cases:$")
     public void matchWithExpresion(String envVar, DataTable table) {
         String jsonString = ThreadProperty.get(envVar);
 
@@ -366,7 +366,7 @@ public class RestSpec extends BaseGSpec {
      * @see #assertResponseStatusLength(Integer, String)
      * @param expectedText  String to find in the response body
      */
-    @Then("^the service response must contain the text '(.*?)'$")
+    @Then("^the service response must contain the text '(.*)'$")
     public void assertResponseMessage(String expectedText) {
         ResponseBody body = commonspec.getRestResponse().getBody();
         String bodyAsString = body.asString();
@@ -408,7 +408,7 @@ public class RestSpec extends BaseGSpec {
      * @param element  key in the json response to be saved
      * @param envVar   thread environment variable where to store the value
      */
-    @Given("^I save element (in position \'(.+?)\' in )?\'(.+?)\' in environment variable \'(.+?)\'$")
+    @Given("^I save element (in position '(.+?)' in )?'(.+?)' in environment variable '(.+?)'$")
     public void saveElementEnvironment(String position, String element, String envVar) {
 
         Pattern pattern = Pattern.compile("^((.*)(\\.)+)(\\$.*)$");
@@ -617,7 +617,7 @@ public class RestSpec extends BaseGSpec {
      * @throws InterruptedException InterruptedException
      */
     @Deprecated
-    @When("^in less than '(\\d+?)' seconds, checking each '(\\d+?)' seconds, I send a '(.+?)' request to '(.+?)' so that the response( does not)? contains '(.+?)'$")
+    @When("^in less than '(\\d+)' seconds, checking each '(\\d+)' seconds, I send a '(.*)' request to '(.*)' so that the response( does not)? contains '(.*)'$")
     public void sendRequestTimeout(Integer timeout, Integer wait, String requestType, String endPoint, String contains, String responseVal) throws InterruptedException {
 
         Boolean searchUntilContains;
@@ -775,7 +775,7 @@ public class RestSpec extends BaseGSpec {
      * @param headerName    Header name
      * @param varName       Name of the environmental variable
      */
-    @And("^I save the response header '(.+?)' in environment variable '(.+?)'$")
+    @And("^I save the response header '(.*)' in environment variable '(.*)'$")
     public void saveHeaderValue(String headerName, String varName) {
 
         String headerValue = commonspec.getRestResponse().getHeaders().getValue(headerName);
@@ -791,7 +791,7 @@ public class RestSpec extends BaseGSpec {
      * @param varName     Name of the environmental variable
      * @throws Throwable  Throwable
      */
-    @And("^I save the response cookie '(.+?)' in environment variable '(.+?)'$")
+    @And("^I save the response cookie '(.*)' in environment variable '(.*)'$")
     public void saveCookieValue(String cookieName, String varName) throws Throwable {
 
         String cookieValue = commonspec.getRestResponse().getCookies().get(cookieName);
@@ -891,7 +891,7 @@ public class RestSpec extends BaseGSpec {
      * @param filePath      file path
      * @throws URISyntaxException    URISyntaxException
      */
-    @And("^I add the file in '(.+?)' to the request$")
+    @And("^I add the file in '(.*)' to the request$")
     public void iAddTheFileToTheRequest(String filePath) throws URISyntaxException {
 
         URL url = getClass().getClassLoader().getResource(filePath);

--- a/src/main/java/com/privalia/qa/specs/SeleniumGSpec.java
+++ b/src/main/java/com/privalia/qa/specs/SeleniumGSpec.java
@@ -8,6 +8,7 @@ import cucumber.api.java.en.And;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
+import org.apache.kafka.common.protocol.types.Field;
 import org.assertj.core.api.Assertions;
 import org.openqa.selenium.*;
 import org.openqa.selenium.interactions.Actions;
@@ -29,6 +30,8 @@ import static com.privalia.qa.assertions.Assertions.assertThat;
  * @author José Fernández
  */
 public class SeleniumGSpec extends BaseGSpec {
+
+    private final String LOCATORS = "id|name|class|css|xpath|linkText|partialLinkText|tagName";
 
 
     /**
@@ -57,7 +60,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @see #iGoToUrl(String)
      * @param host host where app is running (i.e "localhost" or "localhost:443")
      */
-    @Given("^My app is running in '(.+?)'$")
+    @Given("^My app is running in '(.*)'$")
     public void setupApp(String host) {
         assertThat(host).isNotEmpty();
 
@@ -100,7 +103,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param isSecured If the connection should be secured
      * @param path      path of running app
      */
-    @Given("^I( securely)? browse to '(.+?)'$")
+    @Given("^I( securely)? browse to '(.*)'$")
     public void seleniumBrowse(String isSecured, String path) {
         assertThat(path).isNotEmpty();
 
@@ -139,7 +142,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param element         webElement searched in selenium context
      * @param type            The expected style of the element: visible, clickable, present, hidden
      */
-    @Then("^I check every '(\\d+)' seconds for at least '(\\d+)' seconds until '(\\d+)' elements exists with '([^:]*?):(.+?)' and is '(visible|clickable|present|hidden)'$")
+    @Then("^I check every '(\\d+)' seconds for at least '(\\d+)' seconds until '(\\d+)' elements exists with '(" + LOCATORS + "):(.*)' and is '(visible|clickable|present|hidden)'$")
     public void waitWebElementWithPooling(int poolingInterval, int poolMaxTime, int elementsCount, String method, String element, String type) {
         List<WebElement> wel = commonspec.locateElementWithPooling(poolingInterval, poolMaxTime, method, element, elementsCount, type);
         PreviousWebElements pwel = new PreviousWebElements(wel);
@@ -222,7 +225,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param fileName Name of the file relative to schemas folder (schemas/myFile.txt)
      * @param index    Index of the web element (file input)
      */
-    @Then("^I assign the file in '(.+?)' to the element on index '(\\d+)'$")
+    @Then("^I assign the file in '(.*)' to the element on index '(\\d+)'$")
     public void iSetTheFileInSchemasEmptyJsonToTheElementOnIndex(String fileName, int index) {
 
         //Get file absolute path
@@ -266,7 +269,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * </pre>
      * @param index the index
      */
-    @Given("^I switch to the iframe on index '(\\d+?)'$")
+    @Given("^I switch to the iframe on index '(\\d+)'$")
     public void seleniumSwitchFrame(Integer index) {
 
         Assertions.assertThat(commonspec.getPreviousWebElements().getPreviousWebElements().size()).as("Could not get webelement with index %s. Less elements were found. Allowed index: 0 to %s", index, commonspec.getPreviousWebElements().getPreviousWebElements().size() - 1)
@@ -289,7 +292,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param method  the method (id, class, name, xpath)
      * @param idframe locator
      */
-    @Given("^I switch to iframe with '([^:]*?):(.+?)'$")
+    @Given("^I switch to iframe with '(" + LOCATORS + "):(.*)'$")
     public void seleniumIdFrame(String method, String idframe) {
         assertThat(commonspec.locateElement(method, idframe, 1));
 
@@ -371,7 +374,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param index the index of the webelement
      * @param text  the text to verify
      */
-    @Then("^the element on index '(\\d+?)' has '(.+?)' as text$")
+    @Then("^the element on index '(\\d+)' has '(.*)' as text$")
     public void assertSeleniumTextOnElementPresent(Integer index, String text) {
         Assertions.assertThat(commonspec.getPreviousWebElements().getPreviousWebElements().size()).as("Could not get webelement with index %s. Less elements were found. Allowed index: 0 to %s", index, commonspec.getPreviousWebElements().getPreviousWebElements().size() - 1)
                 .isGreaterThanOrEqualTo(index + 1);
@@ -429,7 +432,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param method        method to locate the elements (id, name, class, css, xpath, linkText, partialLinkText and tagName)
      * @param element       the relative reference to the element
      */
-    @Then("^(at least )?'(\\d+?)' elements? exists? with '([^:]*?):(.+?)'$")
+    @Then("^(at least )?'(\\d+)' elements? exists? with '(" + LOCATORS + "):(.*)'$")
     public void assertSeleniumNElementExists(String atLeast, Integer expectedCount, String method, String element) {
 
         List<WebElement> wel;
@@ -470,7 +473,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param element                   The web element element
      * @throws InterruptedException     The interrupted exception
      */
-    @Then("^in less than '(\\d+?)' seconds, checking each '(\\d+?)' seconds, '(\\d+?)' elements exists with '([^:]*?):(.+?)'$")
+    @Then("^in less than '(\\d+)' seconds, checking each '(\\d+)' seconds, '(\\d+)' elements exists with '(" + LOCATORS + "):(.*)'$")
     public void assertSeleniumNElementExistsOnTimeOut(Integer timeout, Integer wait, Integer expectedCount,
                                                       String method, String element) throws InterruptedException {
         List<WebElement> wel = null;
@@ -626,7 +629,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param attribute the attribute to verify
      * @param value     the value of the attribute
      */
-    @Then("^the element on index '(\\d+?)' has '(.+?)' as '(.+?)'$")
+    @Then("^the element on index '(\\d)' has '(" + LOCATORS + ")' as '(.*)'$")
     public void assertSeleniumHasAttributeValue(Integer index, String attribute, String value) {
         Assertions.assertThat(commonspec.getPreviousWebElements().getPreviousWebElements().size()).as("Could not get webelement with index %s. Less elements were found. Allowed index: 0 to %s", index, commonspec.getPreviousWebElements().getPreviousWebElements().size() - 1)
                 .isGreaterThanOrEqualTo(index + 1);
@@ -665,7 +668,7 @@ public class SeleniumGSpec extends BaseGSpec {
      *
      * @param url the url to verify
      */
-    @Then("^we are in page '(.+?)'$")
+    @Then("^we are in page '(.*)'$")
     public void checkURL(String url) {
         Assertions.assertThat(commonspec.getDriver().getCurrentUrl()).as("We are not in the expected url").isEqualTo(url);
     }
@@ -683,7 +686,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * </pre>
      * @param text  Text to look for in the current url
      */
-    @Then("^the current url contains the text '(.+?)'$")
+    @Then("^the current url contains the text '(.*)'$")
     public void checkURLContains(String text) {
         Assertions.assertThat(commonspec.getDriver().getCurrentUrl()).as("We are not in the expected url").contains(text);
     }
@@ -720,7 +723,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param index  position of the element in the array of webElements found
      * @param envVar name of the thread environment variable where to store the text
      */
-    @Then("^I save content of element in index '(\\d+?)' in environment variable '(.+?)'$")
+    @Then("^I save content of element in index '(\\d+)' in environment variable '(.*)'$")
     public void saveContentWebElementInEnvVar(Integer index, String envVar) {
         Assertions.assertThat(commonspec.getPreviousWebElements().getPreviousWebElements().size()).as("Could not get webelement with index %s. Less elements were found. Allowed index: 0 to %s", index, commonspec.getPreviousWebElements().getPreviousWebElements().size() - 1)
                 .isGreaterThanOrEqualTo(index + 1);
@@ -751,7 +754,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param textValue      Value expected in the property
      * @param customProperty Property of webElement to verify
      */
-    @Then("^the element in index '(.+?)' has '(.+?)' in property '(.+?)'$")
+    @Then("^the element in index '(.*)' has '(.*)' in property '(.*)'$")
     public void theElementOnIndexHasTextInCustomPropertyName(int index, String textValue, String customProperty) {
 
         List<WebElement> wel = commonspec.getPreviousWebElements().getPreviousWebElements();
@@ -772,7 +775,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param dmethod     the dmethod
      * @param destination destination web element
      */
-    @When("^I drag '([^:]*?):(.+?)' and drop it to '([^:]*?):(.+?)'$")
+    @When("^I drag '(.*):(.*)' and drop it to '(.*):(.*)'$")
     public void seleniumDrag(String smethod, String source, String dmethod, String destination) {
         Actions builder = new Actions(commonspec.getDriver());
 
@@ -805,12 +808,74 @@ public class SeleniumGSpec extends BaseGSpec {
      * @see #seleniumClickByLocator(String, String, Integer)
      * @param index Index of the webelement in the list
      */
-    @When("^I click on the element on index '(\\d+?)'$")
+    @When("^I click on the element on index '(\\d+)'$")
     public void seleniumClick(Integer index) {
 
         Assertions.assertThat(commonspec.getPreviousWebElements().getPreviousWebElements().size()).as("Could not get webelement with index %s. Less elements were found. Allowed index: 0 to %s", index, commonspec.getPreviousWebElements().getPreviousWebElements().size() - 1)
                 .isGreaterThanOrEqualTo(index + 1);
+
         commonspec.getPreviousWebElements().getPreviousWebElements().get(index).click();
+
+    }
+
+    /**
+     * Double clicks on an numbered {@code url} previously found element.
+     * <p>
+     * This step requires a previous operation for finding elements to have been executed, such as: <br>
+     * {@link SeleniumGSpec#assertSeleniumNElementExists(String, Integer, String, String)} <br>
+     * {@link SeleniumGSpec#assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)} <br>
+     * {@link SeleniumGSpec#waitWebElementWithPooling(int, int, int, String, String, String)}<br>.
+     * <pre>
+     * Example:
+     * {@code
+     *      When '1' elements exists with 'id:doubleClickBtn'
+     *      And I double click on the element on index '0'
+     * }
+     * </pre>
+     * @see #seleniumDoubleClickByLocator(String, String, Integer)
+     * @see #assertSeleniumNElementExists(String, Integer, String, String)
+     * @see #assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)
+     * @see #waitWebElementWithPooling(int, int, int, String, String, String)
+     * @param index Index of the webelement in the list
+     */
+    @When("^I double click on the element on index '(\\d+)'$")
+    public void seleniumDoubleClick(Integer index) {
+
+        Assertions.assertThat(commonspec.getPreviousWebElements().getPreviousWebElements().size()).as("Could not get webelement with index %s. Less elements were found. Allowed index: 0 to %s", index, commonspec.getPreviousWebElements().getPreviousWebElements().size() - 1)
+                .isGreaterThanOrEqualTo(index + 1);
+        Actions actions = new Actions(this.commonspec.getDriver());
+        actions.doubleClick(commonspec.getPreviousWebElements().getPreviousWebElements().get(index)).perform();
+
+    }
+
+    /**
+     * Right clicks on an numbered {@code url} previously found element.
+     * <p>
+     * This step requires a previous operation for finding elements to have been executed, such as: <br>
+     * {@link SeleniumGSpec#assertSeleniumNElementExists(String, Integer, String, String)} <br>
+     * {@link SeleniumGSpec#assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)} <br>
+     * {@link SeleniumGSpec#waitWebElementWithPooling(int, int, int, String, String, String)}<br>.
+     * <pre>
+     * Example:
+     * {@code
+     *      When '1' elements exists with 'id:rightClickBtn'
+     *      And I right click on the element on index '0'
+     * }
+     * </pre>
+     * @see #seleniumRightClickByLocator(String, String, Integer)
+     * @see #assertSeleniumNElementExists(String, Integer, String, String)
+     * @see #assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)
+     * @see #waitWebElementWithPooling(int, int, int, String, String, String)
+     * @param index Index of the webelement in the list
+     */
+    @When("^I right click on the element on index '(\\d+)'$")
+    public void seleniumRightClick(Integer index) {
+
+        Assertions.assertThat(commonspec.getPreviousWebElements().getPreviousWebElements().size()).as("Could not get webelement with index %s. Less elements were found. Allowed index: 0 to %s", index, commonspec.getPreviousWebElements().getPreviousWebElements().size() - 1)
+                .isGreaterThanOrEqualTo(index + 1);
+        Actions actions = new Actions(this.commonspec.getDriver());
+        actions.contextClick(commonspec.getPreviousWebElements().getPreviousWebElements().get(index)).perform();
+
     }
 
 
@@ -835,7 +900,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @see #waitWebElementWithPooling(int, int, int, String, String, String)
      * @param index index of the web element
      */
-    @When("^I clear the content on text input at index '(\\d+?)'$")
+    @When("^I clear the content on text input at index '(\\d+)'$")
     public void seleniumClear(Integer index) {
         Assertions.assertThat(commonspec.getPreviousWebElements().getPreviousWebElements().size()).as("Could not get webelement with index %s. Less elements were found. Allowed index: 0 to %s", index, commonspec.getPreviousWebElements().getPreviousWebElements().size() - 1)
                 .isGreaterThanOrEqualTo(index + 1);
@@ -852,7 +917,9 @@ public class SeleniumGSpec extends BaseGSpec {
      * This step requires a previous operation for finding elements to have been executed, such as: <br>
      * {@link SeleniumGSpec#assertSeleniumNElementExists(String, Integer, String, String)} <br>
      * {@link SeleniumGSpec#assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)} <br>
-     * {@link SeleniumGSpec#waitWebElementWithPooling(int, int, int, String, String, String)}
+     * {@link SeleniumGSpec#waitWebElementWithPooling(int, int, int, String, String, String)}<br>
+     * You can also use the step {@link #seleniumTypeByLocator(String, String, String, Integer)} to directly type the given
+     * text in the element
      *
      * <pre>
      * Example:
@@ -862,13 +929,14 @@ public class SeleniumGSpec extends BaseGSpec {
      *      And I clear the content on text input at index '0'
      * }
      * </pre>
+     * @see #seleniumTypeByLocator(String, String, String, Integer)
      * @see #assertSeleniumNElementExists(String, Integer, String, String)
      * @see #assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)
      * @see #waitWebElementWithPooling(int, int, int, String, String, String)
      * @param input Text to write on the element
      * @param index Index of the webelement in the list
      */
-    @When("^I type '(.+?)' on the element on index '(\\d+?)'$")
+    @When("^I type '(.*)' on the element on index '(\\d+)'$")
     public void seleniumType(String input, Integer index) {
 
         NullableStringConverter converter = new NullableStringConverter();
@@ -920,7 +988,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param text  key stroke to send
      * @param index index of the web element in the list
      */
-    @When("^I send '(.+?)'( on the element on index '(\\d+?)')?$")
+    @When("^I send '(.+?)'( on the element on index '(\\d+)')?$")
     public void seleniumKeys(String text, Integer index) {
 
         ArrayListConverter converter = new ArrayListConverter();
@@ -969,7 +1037,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param option option in the select element
      * @param index  index of the web element in the list
      */
-    @When("^I select '(.+?)' on the element on index '(\\d+?)'$")
+    @When("^I select '(.*)' on the element on index '(\\d+)'$")
     public void elementSelect(String option, Integer index) {
         Select sel = null;
         sel = new Select(commonspec.getPreviousWebElements().getPreviousWebElements().get(index));
@@ -988,7 +1056,7 @@ public class SeleniumGSpec extends BaseGSpec {
      *
      * @param index index of the web element in the list
      */
-    @When("^I de-select every item on the element on index '(\\d+?)'$")
+    @When("^I de-select every item on the element on index '(\\d+)'$")
     public void elementDeSelect(Integer index) {
         Select sel = null;
         sel = new Select(commonspec.getPreviousWebElements().getPreviousWebElements().get(index));
@@ -1049,7 +1117,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param index        Index of the webelement in the list
      * @param variable     Variable where to save the result
      */
-    @Then("^I save the value of the property '(.+?)' of the element in index '(.+?)' in variable '(.+?)'$")
+    @Then("^I save the value of the property '(.*)' of the element in index '(.*)' in variable '(.*)'$")
     public void iSaveTheValueOfThePropertyHrefOfTheElementInIndexInVariableVAR(String propertyName, int index, String variable) {
         List<WebElement> wel = commonspec.getPreviousWebElements().getPreviousWebElements();
         String value = wel.get(index).getAttribute(propertyName);
@@ -1085,7 +1153,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param index  If used, the index of the previously found web element on which to execute the function
      * @param enVar  If used, variable where to store the result of the execution of the script
      */
-    @Then("^I execute '(.+?)' as javascript( on the element on index '(.+?)')?( and save the result in the environment variable '(.+?)')?$")
+    @Then("^I execute '(.*)' as javascript( on the element on index '(.*)')?( and save the result in the environment variable '(.*)')?$")
     public void iExecuteTheScriptScriptOnTheElmentOnIndex(String script, String index, String enVar) {
 
         JavascriptExecutor executor = (JavascriptExecutor) this.commonspec.getDriver();
@@ -1126,7 +1194,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @see #seleniumBrowse(String, String)
      * @param url   Url were to navigate
      */
-    @Given("I go to '(.+?)'")
+    @Given("I go to '(.*)'")
     public void iGoToUrl(String url) {
 
         if (!url.toLowerCase().contains("http://") && !url.toLowerCase().contains("https://")) {
@@ -1144,7 +1212,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * but, it does not require a previous operation for finding elements, such as {@link #assertSeleniumNElementExists(String, Integer, String, String)}
      * or {@link #assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)}. If the page contains
      * several web elements with the given locator, the click action will be performed to the first element found by default,
-     * unless an index is specified
+     * unless an index is specified (first element has index 0)
      * <pre>
      * Example: Perform click on the element with id 'username'
      * {@code
@@ -1162,13 +1230,47 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param element       the relative reference to the element
      * @param index         Index of the element, in case one or more elements with the given locator are found (first element starts with index 0)
      */
-    @Then("^I click on the element with '([^:]*?):(.+?)'( index '(.+?)')?$")
+    @Then("^I click on the element with '(" + LOCATORS + "):(.*)'( index '(\\d+)')?$")
     public void seleniumClickByLocator(String method, String element, Integer index) {
         this.assertSeleniumNElementExists("at least", 1, method, element);
         if (index == null) {
             index = 0;
         }
         this.seleniumClick(index);
+    }
+
+    /**
+     * Directly types the given text in the element referenced by locator.
+     * <p>
+     * This steps types the given text on the given web element. This step is similar to {@link #seleniumType(String, Integer)}
+     * but, it does not require a previous operation for finding elements, such as {@link #assertSeleniumNElementExists(String, Integer, String, String)}
+     * or {@link #assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)}. If the page contains
+     * several web elements with the given locator, the click action will be performed to the first element found by default,
+     * unless an index is specified (first element has index 0)
+     * <pre>
+     * Example: Type 555-555 in the input field with id:phone_number
+     * {@code
+     *      And I type '555-555' on the element with 'id:phone_number'
+     * }
+     * Example: Using index in case more than one element is found (first element has index 0)
+     * {@code
+     *      And I type '555-555' on the element with 'class:text-field' index 1
+     * }
+     * </pre>
+     *
+     * @see #seleniumType(String, Integer)
+     * @param input     text to type in the element
+     * @param method    method to locate the elements (id, name, class, css, xpath, linkText, partialLinkText and tagName)
+     * @param element   the relative reference to the element
+     * @param index     Index of the element, in case one or more elements with the given locator are found (first element starts with index 0)
+     */
+    @When("^I type '(.*)' on the element with '(" + LOCATORS + "):(.*)'( index '(\\d+)')?$")
+    public void seleniumTypeByLocator(String input, String method, String element, Integer index) {
+        this.assertSeleniumNElementExists("at least", 1, method, element);
+        if (index == null) {
+            index = 0;
+        }
+        this.seleniumType(input, index);
     }
 
     @And("^I go back (\\d+) (?:page|pages)?$")
@@ -1184,5 +1286,141 @@ public class SeleniumGSpec extends BaseGSpec {
             this.commonspec.getDriver().navigate().forward();
         }
     }
+
+    /**
+     * Scrolls the page up or down until the element referenced by index is visible
+     * <p>
+     * This step executes a javascript function to automatically scroll the element into view. The web element is referenced
+     * by its index, to  it does require a previous operation for finding elements, such as {@link #assertSeleniumNElementExists(String, Integer, String, String)}
+     * or {@link #assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)} to be executed first.
+     * <pre>
+     * Example: Scroll until the submit button is visible, then, click on it
+     * {@code
+     *      And at least '1' elements exists with 'id:submit'
+     *      Then I scroll down until the element on index '0' is visible
+     *      Then I click on the element on index '0'
+     * }
+     * </pre>
+     * @see #assertSeleniumNElementExists(String, Integer, String, String)
+     * @see #assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)
+     * @param direction             Indicates if the scroll is upwards or downwards
+     * @param index                 Index of the web element
+     * @throws InterruptedException InterruptedException
+     */
+    @Then("^I scroll (up|down) until the element on index '(\\d+)' is visible$")
+    public void scrollUntilElementVisible(String direction, int index) throws InterruptedException {
+        Assertions.assertThat(commonspec.getPreviousWebElements().getPreviousWebElements().size()).as("Could not get webelement with index %s. Less elements were found. Allowed index: 0 to %s", index, commonspec.getPreviousWebElements().getPreviousWebElements().size() - 1)
+                .isGreaterThanOrEqualTo(index + 1);
+
+        String script;
+
+        if (direction.matches("up")) {
+            script = "arguments[0].scrollIntoView(false);";
+        } else {
+            script = "arguments[0].scrollIntoView(true);";
+        }
+
+        ((JavascriptExecutor) this.commonspec.getDriver()).executeScript(script, this.commonspec.getPreviousWebElements().getPreviousWebElements().get(index));
+        Thread.sleep(500);
+    }
+
+    /**
+     * Directly scrolls the page up or down until the element is visible
+     * <p>
+     * This step executes a javascript function to automatically scroll the element into view. This step is similar to {@link #scrollUntilElementVisible(String, int)}
+     * but it does not require a previous operation for finding elements to be executed, since the element is directly referenced as a locator
+     * <pre>
+     * Example: Scroll up and down the page until the referenced element is visible
+     * {@code
+     *      Then I scroll up until the element with 'id:userName' is visible
+     *      Then I scroll down until the element with 'id:submit' is visible
+     *      Then I click on the element with 'id:submit'
+     * }
+     * </pre>
+     * @see #scrollUntilElementVisible(String, int)
+     * @param direction                 Indicates if the scroll is upwards or downwards
+     * @param method                    method to locate the elements (id, name, class, css, xpath, linkText, partialLinkText and tagName)
+     * @param element                   The relative reference to the element
+     * @param index                     Index of the element, in case one or more elements with the given locator are found (first element starts with index 0)
+     * @throws InterruptedException
+     */
+    @Then("^I scroll (up|down) until the element with '(" + LOCATORS +  "):(.*)'( index '(\\d+)')? is visible$")
+    public void scrollUntilElementVisibleByLocator(String direction, String method, String element, Integer index) throws InterruptedException {
+        this.assertSeleniumNElementExists("at least", 1, method, element);
+        if (index == null) {
+            index = 0;
+        }
+        this.scrollUntilElementVisible(direction, index);
+    }
+
+    /**
+     * Directly double clicks the given element referenced by locator
+     * <p>
+     * This step performs a double click action on the element. This step is similar to {@link #seleniumDoubleClick(Integer)}
+     * but, it does not require a previous operation for finding elements, such as {@link #assertSeleniumNElementExists(String, Integer, String, String)}
+     * or {@link #assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)}. If the page contains
+     * several web elements with the given locator, the double click action will be performed to the first element found by default,
+     * unless an index is specified (first element has index 0)
+     * <pre>
+     * Example: Perform double click on the element with id 'doubleClickBtn'
+     * {@code
+     *      When I double click on the element with 'id:doubleClickBtn'
+     * }
+     * Example: Using index in case more than one element is found (first element has index 0)
+     * {@code
+     *      When I double click on the element with 'tagName:button' index 1  //clicks the second element with tag name 'button'
+     * }
+     * </pre>
+     * @see #seleniumDoubleClick(Integer)
+     * @see #assertSeleniumNElementExists(String, Integer, String, String)
+     * @see #assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)
+     * @param method        method to locate the elements (id, name, class, css, xpath, linkText, partialLinkText and tagName)
+     * @param element       the relative reference to the element
+     * @param index         Index of the element, in case one or more elements with the given locator are found (first element starts with index 0)
+     */
+    @Then("^I double click on the element with '(" + LOCATORS + "):(.*)'( index '(\\d+)')?$")
+    public void seleniumDoubleClickByLocator(String method, String element, Integer index) {
+        this.assertSeleniumNElementExists("at least", 1, method, element);
+        if (index == null) {
+            index = 0;
+        }
+        this.seleniumDoubleClick(index);
+    }
+
+
+    /**
+     * Directly right clicks the given element referenced by locator
+     * <p>
+     * This step performs a right click action on the element. This step is similar to {@link #seleniumRightClick(Integer)}
+     * but, it does not require a previous operation for finding elements, such as {@link #assertSeleniumNElementExists(String, Integer, String, String)}
+     * or {@link #assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)}. If the page contains
+     * several web elements with the given locator, the right click action will be performed to the first element found by default,
+     * unless an index is specified (first element has index 0)
+     * <pre>
+     * Example: Perform right click on the element with id 'rightClickBtn'
+     * {@code
+     *      When I right click on the element with 'id:rightClickBtn'
+     * }
+     * Example: Using index in case more than one element is found (first element has index 0)
+     * {@code
+     *      When I right click on the element with 'tagName:button' index 1  //clicks the second element with tag name 'button'
+     * }
+     * </pre>
+     * @see #seleniumRightClick(Integer)
+     * @see #assertSeleniumNElementExists(String, Integer, String, String)
+     * @see #assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)
+     * @param method        method to locate the elements (id, name, class, css, xpath, linkText, partialLinkText and tagName)
+     * @param element       the relative reference to the element
+     * @param index         Index of the element, in case one or more elements with the given locator are found (first element starts with index 0)
+     */
+    @Then("^I right click on the element with '(" + LOCATORS + "):(.*)'( index '(\\d+)')?$")
+    public void seleniumRightClickByLocator(String method, String element, Integer index) {
+        this.assertSeleniumNElementExists("at least", 1, method, element);
+        if (index == null) {
+            index = 0;
+        }
+        this.seleniumRightClick(index);
+    }
+
 
 }

--- a/src/main/java/com/privalia/qa/specs/SeleniumGSpec.java
+++ b/src/main/java/com/privalia/qa/specs/SeleniumGSpec.java
@@ -1342,7 +1342,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param method                    method to locate the elements (id, name, class, css, xpath, linkText, partialLinkText and tagName)
      * @param element                   The relative reference to the element
      * @param index                     Index of the element, in case one or more elements with the given locator are found (first element starts with index 0)
-     * @throws InterruptedException
+     * @throws InterruptedException     InterruptedException
      */
     @Then("^I scroll (up|down) until the element with '(" + LOCATORS +  "):(.*)'( index '(\\d+)')? is visible$")
     public void scrollUntilElementVisibleByLocator(String direction, String method, String element, Integer index) throws InterruptedException {

--- a/src/main/java/com/privalia/qa/specs/SeleniumGSpec.java
+++ b/src/main/java/com/privalia/qa/specs/SeleniumGSpec.java
@@ -988,7 +988,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param text  key stroke to send
      * @param index index of the web element in the list
      */
-    @When("^I send '(.+?)'( on the element on index '(\\d+)')?$")
+    @When("^I send '(.*)'( on the element on index '(\\d+)')?$")
     public void seleniumKeys(String text, Integer index) {
 
         ArrayListConverter converter = new ArrayListConverter();

--- a/src/main/java/com/privalia/qa/specs/SeleniumGSpec.java
+++ b/src/main/java/com/privalia/qa/specs/SeleniumGSpec.java
@@ -988,7 +988,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param text  key stroke to send
      * @param index index of the web element in the list
      */
-    @When("^I send '(.*)'( on the element on index '(\\d+)')?$")
+    @When("^I send '(.*)' on the element on index '(\\d+)'$")
     public void seleniumKeys(String text, Integer index) {
 
         ArrayListConverter converter = new ArrayListConverter();
@@ -1230,7 +1230,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param element       the relative reference to the element
      * @param index         Index of the element, in case one or more elements with the given locator are found (first element starts with index 0)
      */
-    @Then("^I click on the element with '(" + LOCATORS + "):(.*)'( index '(\\d+)')?$")
+    @Then("^I click on the element with '(" + LOCATORS + "):(.*?)'( index '(\\d+)')?$")
     public void seleniumClickByLocator(String method, String element, Integer index) {
         this.assertSeleniumNElementExists("at least", 1, method, element);
         if (index == null) {
@@ -1264,7 +1264,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param element   the relative reference to the element
      * @param index     Index of the element, in case one or more elements with the given locator are found (first element starts with index 0)
      */
-    @When("^I type '(.*)' on the element with '(" + LOCATORS + "):(.*)'( index '(\\d+)')?$")
+    @When("^I type '(.*)' on the element with '(" + LOCATORS + "):(.*?)'( index '(\\d+)')?$")
     public void seleniumTypeByLocator(String input, String method, String element, Integer index) {
         this.assertSeleniumNElementExists("at least", 1, method, element);
         if (index == null) {
@@ -1301,6 +1301,7 @@ public class SeleniumGSpec extends BaseGSpec {
      *      Then I click on the element on index '0'
      * }
      * </pre>
+     * @see #scrollUntilElementVisibleByLocator(String, String, String, Integer)
      * @see #assertSeleniumNElementExists(String, Integer, String, String)
      * @see #assertSeleniumNElementExistsOnTimeOut(Integer, Integer, Integer, String, String)
      * @param direction             Indicates if the scroll is upwards or downwards
@@ -1344,7 +1345,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param index                     Index of the element, in case one or more elements with the given locator are found (first element starts with index 0)
      * @throws InterruptedException     InterruptedException
      */
-    @Then("^I scroll (up|down) until the element with '(" + LOCATORS +  "):(.*)'( index '(\\d+)')? is visible$")
+    @Then("^I scroll (up|down) until the element with '(" + LOCATORS +  "):(.*?)'( index '(\\d+)')? is visible$")
     public void scrollUntilElementVisibleByLocator(String direction, String method, String element, Integer index) throws InterruptedException {
         this.assertSeleniumNElementExists("at least", 1, method, element);
         if (index == null) {
@@ -1378,7 +1379,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param element       the relative reference to the element
      * @param index         Index of the element, in case one or more elements with the given locator are found (first element starts with index 0)
      */
-    @Then("^I double click on the element with '(" + LOCATORS + "):(.*)'( index '(\\d+)')?$")
+    @Then("^I double click on the element with '(" + LOCATORS + "):(.*?)'( index '(\\d+)')?$")
     public void seleniumDoubleClickByLocator(String method, String element, Integer index) {
         this.assertSeleniumNElementExists("at least", 1, method, element);
         if (index == null) {
@@ -1413,7 +1414,7 @@ public class SeleniumGSpec extends BaseGSpec {
      * @param element       the relative reference to the element
      * @param index         Index of the element, in case one or more elements with the given locator are found (first element starts with index 0)
      */
-    @Then("^I right click on the element with '(" + LOCATORS + "):(.*)'( index '(\\d+)')?$")
+    @Then("^I right click on the element with '(" + LOCATORS + "):(.*?)'( index '(\\d+)')?$")
     public void seleniumRightClickByLocator(String method, String element, Integer index) {
         this.assertSeleniumNElementExists("at least", 1, method, element);
         if (index == null) {
@@ -1421,6 +1422,5 @@ public class SeleniumGSpec extends BaseGSpec {
         }
         this.seleniumRightClick(index);
     }
-
 
 }

--- a/src/main/java/com/privalia/qa/specs/UtilsGSpec.java
+++ b/src/main/java/com/privalia/qa/specs/UtilsGSpec.java
@@ -57,7 +57,7 @@ public class UtilsGSpec extends BaseGSpec {
      * @param seconds                   Seconds to wait
      * @throws InterruptedException     InterruptedException
      */
-    @When("^I wait '(.+?)' seconds?$")
+    @When("^I wait '(\\d+)' seconds?$")
     public void idleWait(Integer seconds) throws InterruptedException {
         Thread.sleep(seconds * DEFAULT_TIMEOUT);
     }
@@ -65,13 +65,19 @@ public class UtilsGSpec extends BaseGSpec {
 
     /**
      * Check value stored in environment variable "is|matches|is higher than|is lower than|contains|is different from" to value provided
-     *
+     * <pre>
+     * Examples:
+     * {@code
+     *      Then '!{content-type}' matches 'application/json; charset=utf-8'   //checks if the value of the variable matches the string 'application/json; charset=utf-8'
+     *      Then '!{DEFEXSTAT}' contains 'total'                               //checks if the value of the variable contains the string 'total'
+     * }
+     * </pre>
      * @param envVar        The env var to verify
      * @param operation     Operation
      * @param value         The value to match against the condition
      * @throws Exception    Exception
      */
-    @Then("^'(.+?)' ((is|matches|is higher than|is lower than|contains|is different from)) '(.+?)'$")
+    @Then("^'(.*)' (is|matches|is higher than|is lower than|contains|is different from) '(.*)'$")
     public void checkValue(String envVar, String operation, String value) throws Exception {
         switch (operation.toLowerCase()) {
             case "is":
@@ -112,7 +118,7 @@ public class UtilsGSpec extends BaseGSpec {
      * @param value  value to be saved
      * @param envVar thread environment variable where to store the value
      */
-    @Given("^I save \'(.+?)\' in variable \'(.+?)\'$")
+    @Given("^I save '(.*)' in variable '(.*)'$")
     public void saveInEnvironment(String value, String envVar) {
         ThreadProperty.set(envVar, value);
     }
@@ -124,7 +130,7 @@ public class UtilsGSpec extends BaseGSpec {
      * @param csvFile       the csv file
      * @throws Exception    the exception
      */
-    @When("^I read info from csv file '(.+?)'$")
+    @When("^I read info from csv file '(.*)'$")
     public void readFromCSV(String csvFile) throws Exception {
         CsvReader rows = new CsvReader(csvFile);
 

--- a/src/test/resources/features/selenium.feature
+++ b/src/test/resources/features/selenium.feature
@@ -168,13 +168,16 @@ Feature: Selenium steps
     And I execute 'return document.URL;' as javascript and save the result in the environment variable 'PAGE'
     And '!{PAGE}' contains 'index.html'
 
-  @ignore @toocomplex
+
   Scenario: Testing direct steps and new locators
-    Given I go to 'https://demoqa.com/'
-    When I click on the element with 'partialLinkText:Sortable'
-    Then the current url contains the text 'sortable'
-    Then I go back 1 page
-    When I click on the element with 'partialLinkText:Resizable'
-    Then the current url contains the text 'resizable'
-    Then I go back 1 page
-    Then I go forward 1 page
+    Given I go to 'http://${DEMO_SITE_HOST}/index.html@p=49.html'
+    When I type 'Jose' on the element with 'id:name_3_firstname'
+    Then I type 'Fernandez' on the element with 'id:name_3_lastname' index '0'
+    Then I click on the element with 'name:radio_4[]' index '0'
+    Then I click on the element with 'name:checkbox_5[]' index '1'
+    Then I click on the element with 'name:checkbox_5[]' index '2'
+    Then I scroll down until the element with 'name:pie_submit' is visible
+    Then I scroll up until the element with 'id:name_3_firstname' is visible
+    Then I scroll down until the element with 'name:pie_submit' is visible
+    Then I click on the element with 'name:pie_submit'
+    Then I wait '3' seconds

--- a/src/test/resources/features/selenium.feature
+++ b/src/test/resources/features/selenium.feature
@@ -168,7 +168,7 @@ Feature: Selenium steps
     And I execute 'return document.URL;' as javascript and save the result in the environment variable 'PAGE'
     And '!{PAGE}' contains 'index.html'
 
-
+  @ignore @toocomplex
   Scenario: Testing direct steps and new locators
     Given I go to 'https://demoqa.com/'
     When I click on the element with 'partialLinkText:Sortable'


### PR DESCRIPTION
Several changes in the regular expression for some steps (especially selenium and rest steps)

ReplacementAspect was changed to final so its functions can be used directly from the class CommonG to get variables at runtime

 Added selenium steps for right-click, double click, scroll until element visible and type directly by a locator

 Selenium features can now be executed via runners without contructor, and also through IntelliJ IDEA directly

Added tagName, LinkText y partialLinkText to the list of supported locator for selenium. Added 3 more steps for selenium